### PR TITLE
Refactor to shared stylesheet and card layout

### DIFF
--- a/cv.html
+++ b/cv.html
@@ -7,40 +7,25 @@
   <meta name="description" content="Short bio and full CV of Maria Federica Norelli, PhD Candidate." />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='0.9em' font-size='90'>🪶</text></svg>">
   <meta name="color-scheme" content="light dark">
-  <style>
-    :root { --bg:#ffffff; --fg:#0f172a; --muted:#64748b; --link:#1f6feb; --card:#f8fafc; --border:#e2e8f0; }
-    @media (prefers-color-scheme: dark){ :root{ --bg:#0b0f14; --fg:#e6edf3; --muted:#9aa4af; --card:#0f141b; --border:#1f2937; } }
-    *{ box-sizing:border-box }
-    body{ margin:0; font-family: ui-sans-serif, -apple-system, system-ui, Segoe UI, Roboto, Helvetica, Arial; background:var(--bg); color:var(--fg); line-height:1.6 }
-    header{ max-width:1000px; margin:auto; padding:32px 20px; display:flex; gap:18px; align-items:center; justify-content:space-between }
-    .brand{ display:flex; gap:16px; align-items:center }
-    .brand img{ width:80px; height:80px; object-fit:cover; border-radius:50%; border:1px solid var(--border) }
-    .brand h1{ margin:0; font-size:clamp(22px,3vw,30px) }
-    .badge{ display:inline-block; padding:2px 8px; border:1px solid var(--border); border-radius:999px; font-size:12px; color:var(--muted); margin-left:8px }
-    nav{ border-top:1px solid var(--border); border-bottom:1px solid var(--border); background:var(--card) }
-    nav .row{ max-width:1000px; margin:auto; padding:10px 20px; display:flex; gap:12px }
-    nav a{ text-decoration:none; color:var(--fg); padding:6px 10px; border-radius:8px }
-    nav a:hover{ background:var(--border) }
-    main{ max-width:1000px; margin:auto; padding:28px 20px; display:grid; gap:24px }
-    section{ padding:18px; border:1px solid var(--border); border-radius:14px; background:var(--card) }
-    h2{ margin:0 0 8px; font-size:1.25rem }
-    .btn{ display:inline-block; padding:10px 16px; border-radius:10px; border:1px solid var(--border); text-decoration:none }
-    .muted{ color:var(--muted) }
-    footer{ border-top:1px solid var(--border); color:var(--muted); text-align:center; padding:20px }
-  </style>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Libre+Baskerville:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
 </head>
 <body>
   <header>
-    <div class="brand">
-      <img src="https://github.com/Mar1aFede.png" alt="Portrait of Maria Federica Norelli" />
-      <div>
-        <h1>CV — Maria Federica Norelli <span class="badge">PhD Candidate</span></h1>
-        <p class="muted"><a href="index.html">← Home</a></p>
+    <div class="container">
+      <div class="brand">
+        <img src="https://github.com/Mar1aFede.png" alt="Portrait of Maria Federica Norelli" />
+        <div>
+          <h1 class="title">CV — Maria Federica Norelli <span class="badge">PhD Candidate</span></h1>
+          <p class="muted"><a href="index.html">← Home</a></p>
+        </div>
       </div>
     </div>
   </header>
 
-  <nav>
+  <nav class="sticky">
     <div class="row">
       <a href="index.html#about">Home</a>
       <a href="research.html">Research</a>
@@ -52,22 +37,26 @@
   </nav>
 
   <main>
-    <section>
-      <h2>Short Bio</h2>
-      <p>I am a PhD Candidate in Philosophy at Northeastern University London. I work in the philosophy of science and the philosophy of AI, with a focus on the epistemology of machine learning (generalization, simplicity, pruning). I hold degrees from the University of Bologna (BA in Philosophy, <em>summa cum laude</em>, 2016; MA in Semiotics, <em>summa cum laude</em>, 2019) and from Northeastern University London (MA in Philosophy & Artificial Intelligence, First-Class Honours, 2022). I am currently completing my PhD (expected Oct 2026), supervised by Ioannis Votsis and colleagues in philosophy and computer science. Alongside my doctoral research, I have served as a Lecturer/Seminar Leader in Logic (LPHIL4228) and as a Research Assistant on projects in AI ethics and in network science for the humanities.</p>
-    </section>
+    <div class="container">
+      <section class="card">
+        <h2 class="subtitle">Short Bio</h2>
+        <p>I am a PhD Candidate in Philosophy at Northeastern University London. I work in the philosophy of science and the philosophy of AI, with a focus on the epistemology of machine learning (generalization, simplicity, pruning). I hold degrees from the University of Bologna (BA in Philosophy, <em>summa cum laude</em>, 2016; MA in Semiotics, <em>summa cum laude</em>, 2019) and from Northeastern University London (MA in Philosophy & Artificial Intelligence, First-Class Honours, 2022). I am currently completing my PhD (expected Oct 2026), supervised by Ioannis Votsis and colleagues in philosophy and computer science. Alongside my doctoral research, I have served as a Lecturer/Seminar Leader in Logic (LPHIL4228) and as a Research Assistant on projects in AI ethics and in network science for the humanities.</p>
+      </section>
 
-    <section>
-      <h2>Full CV</h2>
-      <p class="muted">Last updated: 2 September 2025</p>
-      <p>
-        <a class="btn" href="asset/CV.pdf" target="_blank" rel="noreferrer">Download full CV (PDF)</a>
-      </p>
-    </section>
+      <section class="card">
+        <h2 class="subtitle">Full CV</h2>
+        <p class="muted">Last updated: 2 September 2025</p>
+        <p>
+          <a class="btn" href="asset/CV.pdf" target="_blank" rel="noreferrer">Download full CV (PDF)</a>
+        </p>
+      </section>
+    </div>
   </main>
 
   <footer>
-    © <span id="y"></span> Maria Federica Norelli · Hosted on GitHub Pages
+    <div class="container">
+      © <span id="y"></span> Maria Federica Norelli · Hosted on GitHub Pages
+    </div>
   </footer>
   <script>document.getElementById('y').textContent = new Date().getFullYear();</script>
 </body>

--- a/experience.html
+++ b/experience.html
@@ -7,41 +7,25 @@
   <meta name="description" content="Academic and research experience of Maria Federica Norelli." />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='0.9em' font-size='90'>🪶</text></svg>">
   <meta name="color-scheme" content="light dark">
-  <style>
-    :root { --bg:#ffffff; --fg:#0f172a; --muted:#64748b; --link:#1f6feb; --card:#f8fafc; --border:#e2e8f0; }
-    @media (prefers-color-scheme: dark){ :root{ --bg:#0b0f14; --fg:#e6edf3; --muted:#9aa4af; --card:#0f141b; --border:#1f2937; } }
-    *{ box-sizing:border-box }
-    body{ margin:0; font-family: ui-sans-serif, -apple-system, system-ui, Segoe UI, Roboto, Helvetica, Arial; background:var(--bg); color:var(--fg); line-height:1.6 }
-    header{ max-width:1000px; margin:auto; padding:32px 20px; display:flex; gap:18px; align-items:center; justify-content:space-between }
-    .brand{ display:flex; gap:16px; align-items:center }
-    .brand img{ width:80px; height:80px; object-fit:cover; border-radius:50%; border:1px solid var(--border) }
-    .brand h1{ margin:0; font-size:clamp(22px,3vw,30px) }
-    .badge{ display:inline-block; padding:2px 8px; border:1px solid var(--border); border-radius:999px; font-size:12px; color:var(--muted); margin-left:8px }
-    nav{ border-top:1px solid var(--border); border-bottom:1px solid var(--border); background:var(--card) }
-    nav .row{ max-width:1000px; margin:auto; padding:10px 20px; display:flex; gap:12px; flex-wrap:wrap }
-    nav a{ text-decoration:none; color:var(--fg); padding:6px 10px; border-radius:8px }
-    nav a:hover{ background:var(--border) }
-    main{ max-width:1000px; margin:auto; padding:28px 20px; display:grid; gap:24px }
-    section{ padding:18px; border:1px solid var(--border); border-radius:14px; background:var(--card) }
-    h2{ margin:0 0 8px; font-size:1.25rem }
-    h3{ margin:0 0 6px; font-size:1.05rem }
-    .muted{ color:var(--muted) }
-    ul{ margin:8px 0; padding-left:18px }
-    footer{ border-top:1px solid var(--border); color:var(--muted); text-align:center; padding:20px }
-  </style>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Libre+Baskerville:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
 </head>
 <body>
   <header>
-    <div class="brand">
-      <img src="https://github.com/Mar1aFede.png" alt="Portrait of Maria Federica Norelli" />
-      <div>
-        <h1>Experience — Maria Federica Norelli <span class="badge">PhD Candidate</span></h1>
-        <p class="muted"><a href="index.html">← Home</a></p>
+    <div class="container">
+      <div class="brand">
+        <img src="https://github.com/Mar1aFede.png" alt="Portrait of Maria Federica Norelli" />
+        <div>
+          <h1 class="title">Experience — Maria Federica Norelli <span class="badge">PhD Candidate</span></h1>
+          <p class="muted"><a href="index.html">← Home</a></p>
+        </div>
       </div>
     </div>
   </header>
 
-  <nav>
+  <nav class="sticky">
     <div class="row">
       <a href="index.html#about">Home</a>
       <a href="research.html">Research</a>
@@ -53,29 +37,33 @@
   </nav>
 
   <main>
-    <section>
-      <h2>Academic & Research Roles</h2>
-      <ul>
-        <li><strong>Research Assistant — Reverse Engineering Prompts Project</strong> (Apr 2025 – Present), NU London at Northeastern Ltd — data collection and NLP analysis on AI ethics prompts; qualitative/quantitative trend analysis.</li>
-        <li><strong>Lecturer / Seminar Leader — Introduction to Logic (LPHIL4228)</strong> (Jan 2025 – Apr 2025), Northeastern University London — interactive seminars, assessment design, learning analytics.</li>
-        <li><strong>Research Assistant — Human & Network Sciences: Graph Computing for HSS</strong> (Apr 2024 – Dec 2024), NU London — graph computing notebooks, data prep/cleaning, simulations with PolyGraphs.</li>
-        <li><strong>Research Assistant (Psychophysics) — Cones to Words</strong> (Oct 2021 – Mar 2023), NU London — colour communication experiments; data collection/analysis; manuscripts support.</li>
-      </ul>
-    </section>
+    <div class="container">
+      <section class="card">
+        <h2 class="subtitle">Academic & Research Roles</h2>
+        <ul>
+          <li><strong>Research Assistant — Reverse Engineering Prompts Project</strong> (Apr 2025 – Present), NU London at Northeastern Ltd — data collection and NLP analysis on AI ethics prompts; qualitative/quantitative trend analysis.</li>
+          <li><strong>Lecturer / Seminar Leader — Introduction to Logic (LPHIL4228)</strong> (Jan 2025 – Apr 2025), Northeastern University London — interactive seminars, assessment design, learning analytics.</li>
+          <li><strong>Research Assistant — Human & Network Sciences: Graph Computing for HSS</strong> (Apr 2024 – Dec 2024), NU London — graph computing notebooks, data prep/cleaning, simulations with PolyGraphs.</li>
+          <li><strong>Research Assistant (Psychophysics) — Cones to Words</strong> (Oct 2021 – Mar 2023), NU London — colour communication experiments; data collection/analysis; manuscripts support.</li>
+        </ul>
+      </section>
 
-    <section>
-      <h2>Education</h2>
-      <ul>
-        <li><strong>PhD in Philosophy</strong> (expected Oct 2026), Northeastern University London.</li>
-        <li><strong>MA in Philosophy & Artificial Intelligence</strong> (2022, First-Class Honours), Northeastern University London.</li>
-        <li><strong>MA in Semiotics</strong> (2019, <em>summa cum laude</em>), University of Bologna.</li>
-        <li><strong>BA in Philosophy</strong> (2016, <em>summa cum laude</em>), University of Bologna.</li>
-      </ul>
-    </section>
+      <section class="card">
+        <h2 class="subtitle">Education</h2>
+        <ul>
+          <li><strong>PhD in Philosophy</strong> (expected Oct 2026), Northeastern University London.</li>
+          <li><strong>MA in Philosophy & Artificial Intelligence</strong> (2022, First-Class Honours), Northeastern University London.</li>
+          <li><strong>MA in Semiotics</strong> (2019, <em>summa cum laude</em>), University of Bologna.</li>
+          <li><strong>BA in Philosophy</strong> (2016, <em>summa cum laude</em>), University of Bologna.</li>
+        </ul>
+      </section>
+    </div>
   </main>
 
   <footer>
-    © <span id="y"></span> Maria Federica Norelli · Hosted on GitHub Pages
+    <div class="container">
+      © <span id="y"></span> Maria Federica Norelli · Hosted on GitHub Pages
+    </div>
   </footer>
   <script>document.getElementById('y').textContent = new Date().getFullYear();</script>
 </body>

--- a/index.html
+++ b/index.html
@@ -7,42 +7,26 @@
   <meta name="description" content="Academic website of Maria Federica Norelli — philosophy of science & philosophy of AI." />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='0.9em' font-size='90'>🪶</text></svg>">
   <meta name="color-scheme" content="light dark">
-  <style>
-    :root { --bg:#ffffff; --fg:#0f172a; --muted:#64748b; --link:#1f6feb; --card:#f8fafc; --border:#e2e8f0; }
-    @media (prefers-color-scheme: dark){ :root{ --bg:#0b0f14; --fg:#e6edf3; --muted:#9aa4af; --card:#0f141b; --border:#1f2937; } }
-    *{ box-sizing:border-box }
-    html,body{ margin:0; padding:0; background:var(--bg); color:var(--fg); font-family: ui-sans-serif, -apple-system, system-ui, Segoe UI, Roboto, Helvetica, Arial; line-height:1.6 }
-    a{ color:var(--link) }
-    header{ max-width:1000px; margin:auto; padding:48px 20px; display:flex; gap:24px; align-items:center; justify-content:space-between }
-    .brand{ display:flex; gap:20px; align-items:center }
-    .brand img{ width:110px; height:110px; object-fit:cover; border-radius:50%; border:1px solid var(--border) }
-    .brand h1{ margin:0 0 6px; font-size:clamp(24px,4vw,36px) }
-    .brand p{ margin:0; color:var(--muted) }
-    .badge{ display:inline-block; padding:2px 8px; border:1px solid var(--border); border-radius:999px; font-size:12px; color:var(--muted); margin-left:8px }
-    nav{ border-top:1px solid var(--border); border-bottom:1px solid var(--border); background:var(--card) }
-    nav .row{ max-width:1000px; margin:auto; padding:10px 20px; display:flex; flex-wrap:wrap; gap:12px }
-    nav a{ text-decoration:none; color:var(--fg); padding:6px 10px; border-radius:8px }
-    nav a:hover{ background:var(--border) }
-    main{ max-width:1000px; margin:auto; padding:28px 20px; display:grid; gap:36px }
-    section{ padding:20px; border:1px solid var(--border); border-radius:14px; background:var(--card) }
-    h2{ margin:0 0 8px; font-size:1.25rem }
-    footer{ border-top:1px solid var(--border); color:var(--muted); text-align:center; padding:20px }
-  </style>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Libre+Baskerville:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <!-- HEADER -->
   <header>
-    <div class="brand">
-      <!-- Use GitHub avatar; swap to assets/profile.jpg if you prefer local -->
-      <img src="https://github.com/Mar1aFede.png" alt="Portrait of Maria Federica Norelli" />
-      <div>
-        <h1>Maria Federica Norelli <span class="badge">PhD Candidate</span></h1>
+    <div class="container">
+      <div class="brand">
+        <!-- Use GitHub avatar; swap to assets/profile.jpg if you prefer local -->
+        <img src="https://github.com/Mar1aFede.png" alt="Portrait of Maria Federica Norelli" />
+        <div>
+          <h1 class="title">Maria Federica Norelli <span class="badge">PhD Candidate</span></h1>
+        </div>
       </div>
     </div>
   </header>
 
   <!-- NAV -->
-  <nav>
+  <nav class="sticky">
     <div class="row">
       <a href="index.html#about">Home</a>
       <a href="research.html">Research</a>
@@ -54,23 +38,27 @@
   </nav>
 
   <main>
-    <!-- HOME / ABOUT (minimal + short bio paragraph) -->
-    <section id="about">
-      <h2>About me</h2>
-      <p>
-      I am a PhD student in Philosophy at Northeastern University London. My research lies at the intersection of philosophy of science and artificial intelligence, with a particular focus on the epistemology of machine learning and the quest for automated scientific discovery.
-      </p>
-      <p>
-        In my spare time I write poetry and fiction; a small selection may appear here soon.
-      </p>
-      <p>
-        <a href="mailto:mn2122@students.nchlondon.ac.uk">email</a>
-      </p>
-    </section>
+    <div class="container">
+      <!-- HOME / ABOUT (minimal + short bio paragraph) -->
+      <section class="card" id="about">
+        <h2 class="subtitle">About me</h2>
+        <p>
+        I am a PhD student in Philosophy at Northeastern University London. My research lies at the intersection of philosophy of science and artificial intelligence, with a particular focus on the epistemology of machine learning and the quest for automated scientific discovery.
+        </p>
+        <p>
+          In my spare time I write poetry and fiction; a small selection may appear here soon.
+        </p>
+        <p>
+          <a href="mailto:mn2122@students.nchlondon.ac.uk">email</a>
+        </p>
+      </section>
+    </div>
   </main>
 
   <footer>
-    © <span id="y"></span> Maria Federica Norelli · Hosted on GitHub Pages
+    <div class="container">
+      © <span id="y"></span> Maria Federica Norelli · Hosted on GitHub Pages
+    </div>
   </footer>
   <script>document.getElementById('y').textContent = new Date().getFullYear();</script>
 </body>

--- a/publications.html
+++ b/publications.html
@@ -7,41 +7,25 @@
   <meta name="description" content="Publications and awards of Maria Federica Norelli." />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='0.9em' font-size='90'>🪶</text></svg>">
   <meta name="color-scheme" content="light dark">
-  <style>
-    :root { --bg:#ffffff; --fg:#0f172a; --muted:#64748b; --link:#1f6feb; --card:#f8fafc; --border:#e2e8f0; }
-    @media (prefers-color-scheme: dark){ :root{ --bg:#0b0f14; --fg:#e6edf3; --muted:#9aa4af; --card:#0f141b; --border:#1f2937; } }
-    *{ box-sizing:border-box }
-    body{ margin:0; font-family: ui-sans-serif, -apple-system, system-ui, Segoe UI, Roboto, Helvetica, Arial; background:var(--bg); color:var(--fg); line-height:1.6 }
-    header{ max-width:1000px; margin:auto; padding:32px 20px; display:flex; gap:18px; align-items:center; justify-content:space-between }
-    .brand{ display:flex; gap:16px; align-items:center }
-    .brand img{ width:80px; height:80px; object-fit:cover; border-radius:50%; border:1px solid var(--border) }
-    .brand h1{ margin:0; font-size:clamp(22px,3vw,30px) }
-    .badge{ display:inline-block; padding:2px 8px; border:1px solid var(--border); border-radius:999px; font-size:12px; color:var(--muted); margin-left:8px }
-    nav{ border-top:1px solid var(--border); border-bottom:1px solid var(--border); background:var(--card) }
-    nav .row{ max-width:1000px; margin:auto; padding:10px 20px; display:flex; gap:12px; flex-wrap:wrap }
-    nav a{ text-decoration:none; color:var(--fg); padding:6px 10px; border-radius:8px }
-    nav a:hover{ background:var(--border) }
-    main{ max-width:1000px; margin:auto; padding:28px 20px; display:grid; gap:24px }
-    section{ padding:18px; border:1px solid var(--border); border-radius:14px; background:var(--card) }
-    h2{ margin:0 0 8px; font-size:1.25rem }
-    h3{ margin:0 0 6px; font-size:1.05rem }
-    .muted{ color:var(--muted) }
-    ul{ margin:8px 0; padding-left:18px }
-    footer{ border-top:1px solid var(--border); color:var(--muted); text-align:center; padding:20px }
-  </style>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Libre+Baskerville:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
 </head>
 <body>
   <header>
-    <div class="brand">
-      <img src="https://github.com/Mar1aFede.png" alt="Portrait of Maria Federica Norelli" />
-      <div>
-        <h1>Publications — Maria Federica Norelli <span class="badge">PhD Candidate</span></h1>
-        <p class="muted"><a href="index.html">← Home</a></p>
+    <div class="container">
+      <div class="brand">
+        <img src="https://github.com/Mar1aFede.png" alt="Portrait of Maria Federica Norelli" />
+        <div>
+          <h1 class="title">Publications — Maria Federica Norelli <span class="badge">PhD Candidate</span></h1>
+          <p class="muted"><a href="index.html">← Home</a></p>
+        </div>
       </div>
     </div>
   </header>
 
-  <nav>
+  <nav class="sticky">
     <div class="row">
       <a href="index.html#about">Home</a>
       <a href="research.html">Research</a>
@@ -53,26 +37,30 @@
   </nav>
 
   <main>
-    <section>
-      <h2>Articles</h2>
-      <ul>
-        <li>Norelli, M. F., Votsis, I., &amp; Williamson, J. (2025). <em>The Interplay of Data, Models, and Theories in Machine Learning</em>. <em>Philosophy of Science</em>, 1–16. doi:10.1017/psa.2025.10161.</li>
-        <li>Norelli, M. F. (2023). <em>The Use of Colour Names Over Repeated Trials</em>. In <em>Color and Colorimetry. Multidisciplinary Contributions</em>, Vol. XVIII A.</li>
-      </ul>
-    </section>
+    <div class="container">
+      <section class="card">
+        <h2 class="subtitle">Articles</h2>
+        <ul>
+          <li>Norelli, M. F., Votsis, I., &amp; Williamson, J. (2025). <em>The Interplay of Data, Models, and Theories in Machine Learning</em>. <em>Philosophy of Science</em>, 1–16. doi:10.1017/psa.2025.10161.</li>
+          <li>Norelli, M. F. (2023). <em>The Use of Colour Names Over Repeated Trials</em>. In <em>Color and Colorimetry. Multidisciplinary Contributions</em>, Vol. XVIII A.</li>
+        </ul>
+      </section>
 
-    <section>
-      <h2>Awards & Grants</h2>
-      <ul>
-        <li><strong>W. D. Wright Award</strong> (2023).</li>
-        <li><strong>Philosophy of Science Association (PSA) Travel Grant</strong> (2024).</li>
-        <li><strong>European Philosophy of Science Association (EPSA) Travel Grant</strong> (2025).</li>
-      </ul>
-    </section>
+      <section class="card">
+        <h2 class="subtitle">Awards & Grants</h2>
+        <ul>
+          <li><strong>W. D. Wright Award</strong> (2023).</li>
+          <li><strong>Philosophy of Science Association (PSA) Travel Grant</strong> (2024).</li>
+          <li><strong>European Philosophy of Science Association (EPSA) Travel Grant</strong> (2025).</li>
+        </ul>
+      </section>
+    </div>
   </main>
 
   <footer>
-    © <span id="y"></span> Maria Federica Norelli · Hosted on GitHub Pages
+    <div class="container">
+      © <span id="y"></span> Maria Federica Norelli · Hosted on GitHub Pages
+    </div>
   </footer>
   <script>document.getElementById('y').textContent = new Date().getFullYear();</script>
 </body>

--- a/research.html
+++ b/research.html
@@ -7,41 +7,25 @@
   <meta name="description" content="Research of Maria Federica Norelli: philosophy of science, philosophy of AI, epistemology of machine learning." />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='0.9em' font-size='90'>🪶</text></svg>">
   <meta name="color-scheme" content="light dark">
-  <style>
-    :root { --bg:#ffffff; --fg:#0f172a; --muted:#64748b; --link:#1f6feb; --card:#f8fafc; --border:#e2e8f0; }
-    @media (prefers-color-scheme: dark){ :root{ --bg:#0b0f14; --fg:#e6edf3; --muted:#9aa4af; --card:#0f141b; --border:#1f2937; } }
-    *{ box-sizing:border-box }
-    body{ margin:0; font-family: ui-sans-serif, -apple-system, system-ui, Segoe UI, Roboto, Helvetica, Arial; background:var(--bg); color:var(--fg); line-height:1.6 }
-    header{ max-width:1000px; margin:auto; padding:32px 20px; display:flex; gap:18px; align-items:center; justify-content:space-between }
-    .brand{ display:flex; gap:16px; align-items:center }
-    .brand img{ width:80px; height:80px; object-fit:cover; border-radius:50%; border:1px solid var(--border) }
-    .brand h1{ margin:0; font-size:clamp(22px,3vw,30px) }
-    .badge{ display:inline-block; padding:2px 8px; border:1px solid var(--border); border-radius:999px; font-size:12px; color:var(--muted); margin-left:8px }
-    nav{ border-top:1px solid var(--border); border-bottom:1px solid var(--border); background:var(--card) }
-    nav .row{ max-width:1000px; margin:auto; padding:10px 20px; display:flex; gap:12px; flex-wrap:wrap }
-    nav a{ text-decoration:none; color:var(--fg); padding:6px 10px; border-radius:8px }
-    nav a:hover{ background:var(--border) }
-    main{ max-width:1000px; margin:auto; padding:28px 20px; display:grid; gap:24px }
-    section{ padding:18px; border:1px solid var(--border); border-radius:14px; background:var(--card) }
-    h2{ margin:0 0 8px; font-size:1.25rem }
-    h3{ margin:0 0 6px; font-size:1.05rem }
-    .muted{ color:var(--muted) }
-    ul{ margin:8px 0; padding-left:18px }
-    footer{ border-top:1px solid var(--border); color:var(--muted); text-align:center; padding:20px }
-  </style>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Libre+Baskerville:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
 </head>
 <body>
   <header>
-    <div class="brand">
-      <img src="https://github.com/Mar1aFede.png" alt="Portrait of Maria Federica Norelli" />
-      <div>
-        <h1>Research — Maria Federica Norelli <span class="badge">PhD Candidate</span></h1>
-        <p class="muted"><a href="index.html">← Home</a></p>
+    <div class="container">
+      <div class="brand">
+        <img src="https://github.com/Mar1aFede.png" alt="Portrait of Maria Federica Norelli" />
+        <div>
+          <h1 class="title">Research — Maria Federica Norelli <span class="badge">PhD Candidate</span></h1>
+          <p class="muted"><a href="index.html">← Home</a></p>
+        </div>
       </div>
     </div>
   </header>
 
-  <nav>
+  <nav class="sticky">
     <div class="row">
       <a href="index.html#about">Home</a>
       <a href="research.html">Research</a>
@@ -53,36 +37,40 @@
   </nav>
 
   <main>
-    <section>
-      <h2>Overview</h2>
-      <p>My current research lies at the intersection of the philosophy of science, philosophy of AI, and data- and computational philosophy. I focus on the epistemology of machine learning: how learning from data functions, how stability and simplicity relate to generalization, and when model outputs count as scientific knowledge.</p>
-    </section>
+    <div class="container">
+      <section class="card">
+        <h2 class="subtitle">Overview</h2>
+        <p>My current research lies at the intersection of the philosophy of science, philosophy of AI, and data- and computational philosophy. I focus on the epistemology of machine learning: how learning from data functions, how stability and simplicity relate to generalization, and when model outputs count as scientific knowledge.</p>
+      </section>
 
-    <section>
-      <h2>Dissertation</h2>
-      <p><strong>Working title:</strong> <em>Toward an Epistemology of Machine Learning</em>.</p>
-      <p>The project investigates whether and how machine learning contributes to scientific knowledge. It analyzes the roles of data and phenomena, the relation between models and theories, and how explanation and understanding interact with predictive success. On the technical side, it connects philosophical analyses of simplicity with deep‑learning practice by studying pruning and training dynamics. I introduce a <em>Noise‑Cancelling Razor</em> that captures <em>dynamic simplicity</em>: subnetworks that remain stable under controlled perturbations (e.g., noisy validation signals used to guide early stopping) tend to generalize better. This bridges conceptual debates with empirically testable criteria.</p>
-    </section>
+      <section class="card">
+        <h2 class="subtitle">Dissertation</h2>
+        <p><strong>Working title:</strong> <em>Toward an Epistemology of Machine Learning</em>.</p>
+        <p>The project investigates whether and how machine learning contributes to scientific knowledge. It analyzes the roles of data and phenomena, the relation between models and theories, and how explanation and understanding interact with predictive success. On the technical side, it connects philosophical analyses of simplicity with deep‑learning practice by studying pruning and training dynamics. I introduce a <em>Noise‑Cancelling Razor</em> that captures <em>dynamic simplicity</em>: subnetworks that remain stable under controlled perturbations (e.g., noisy validation signals used to guide early stopping) tend to generalize better. This bridges conceptual debates with empirically testable criteria.</p>
+      </section>
 
-    <section>
-      <h2>Current Projects</h2>
-      <ul>
-        <li><strong>Dynamic Simplicity & Pruning:</strong> From the Lottery Ticket Hypothesis to the Noise‑Cancelling Razor; sparsity, early‑stopping stability, and noise‑cancelling indices.</li>
-        <li><strong>Reverse Prompt Engineering:</strong> Mining and classifying elementary Python questions across forums; mapping to curricula; evaluating LLMs (ChatGPT, Copilot, Gemini, Grok) on foundational skills.</li>
-      </ul>
-    </section>
+      <section class="card">
+        <h2 class="subtitle">Current Projects</h2>
+        <ul>
+          <li><strong>Dynamic Simplicity & Pruning:</strong> From the Lottery Ticket Hypothesis to the Noise‑Cancelling Razor; sparsity, early‑stopping stability, and noise‑cancelling indices.</li>
+          <li><strong>Reverse Prompt Engineering:</strong> Mining and classifying elementary Python questions across forums; mapping to curricula; evaluating LLMs (ChatGPT, Copilot, Gemini, Grok) on foundational skills.</li>
+        </ul>
+      </section>
 
-    <section>
-      <h2>Areas</h2>
-      <ul>
-        <li><strong>AOS:</strong> Philosophy of Science; Epistemology; Philosophy of AI.</li>
-        <li><strong>AOC:</strong> Logic; Philosophy of Language; Philosophy of Mind; Metaphysics.</li>
-      </ul>
-    </section>
+      <section class="card">
+        <h2 class="subtitle">Areas</h2>
+        <ul>
+          <li><strong>AOS:</strong> Philosophy of Science; Epistemology; Philosophy of AI.</li>
+          <li><strong>AOC:</strong> Logic; Philosophy of Language; Philosophy of Mind; Metaphysics.</li>
+        </ul>
+      </section>
+    </div>
   </main>
 
   <footer>
-    © <span id="y"></span> Maria Federica Norelli · Hosted on GitHub Pages
+    <div class="container">
+      © <span id="y"></span> Maria Federica Norelli · Hosted on GitHub Pages
+    </div>
   </footer>
   <script>document.getElementById('y').textContent = new Date().getFullYear();</script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,142 @@
+:root {
+  --bg: #ffffff;
+  --fg: #0f172a;
+  --muted: #64748b;
+  --link: #1f6feb;
+  --card: #f8fafc;
+  --border: #e2e8f0;
+  --gradient: linear-gradient(135deg, #dbeafe, #fdf2f8);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0b0f14;
+    --fg: #e6edf3;
+    --muted: #9aa4af;
+    --card: #0f141b;
+    --border: #1f2937;
+    --gradient: linear-gradient(135deg, #1e293b, #0f172a);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  line-height: 1.6;
+}
+
+a {
+  color: var(--link);
+}
+
+.container {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 0 20px;
+}
+
+.brand {
+  display: flex;
+  gap: 20px;
+  align-items: center;
+}
+
+.brand img {
+  width: 90px;
+  height: 90px;
+  object-fit: cover;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+}
+
+.title {
+  margin: 0;
+  font-family: 'Libre Baskerville', serif;
+  font-size: clamp(24px, 4vw, 36px);
+  background: var(--gradient);
+  -webkit-background-clip: text;
+  color: transparent;
+}
+
+.subtitle {
+  margin: 0 0 8px;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.row {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 10px 20px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.sticky {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  background: var(--card);
+}
+
+nav a {
+  text-decoration: none;
+  color: var(--fg);
+  padding: 6px 10px;
+  border-radius: 8px;
+}
+
+nav a:hover {
+  background: var(--border);
+}
+
+main {
+  padding: 28px 0;
+  display: grid;
+  gap: 24px;
+}
+
+.card {
+  padding: 20px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--card);
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  font-size: 12px;
+  color: var(--muted);
+  margin-left: 8px;
+}
+
+.btn {
+  display: inline-block;
+  padding: 10px 16px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  text-decoration: none;
+}
+
+footer {
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  text-align: center;
+  padding: 20px 0;
+}

--- a/talks.html
+++ b/talks.html
@@ -7,41 +7,25 @@
   <meta name="description" content="Talks and workshops by Maria Federica Norelli." />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='0.9em' font-size='90'>🪶</text></svg>">
   <meta name="color-scheme" content="light dark">
-  <style>
-    :root { --bg:#ffffff; --fg:#0f172a; --muted:#64748b; --link:#1f6feb; --card:#f8fafc; --border:#e2e8f0; }
-    @media (prefers-color-scheme: dark){ :root{ --bg:#0b0f14; --fg:#e6edf3; --muted:#9aa4af; --card:#0f141b; --border:#1f2937; } }
-    *{ box-sizing:border-box }
-    body{ margin:0; font-family: ui-sans-serif, -apple-system, system-ui, Segoe UI, Roboto, Helvetica, Arial; background:var(--bg); color:var(--fg); line-height:1.6 }
-    header{ max-width:1000px; margin:auto; padding:32px 20px; display:flex; gap:18px; align-items:center; justify-content:space-between }
-    .brand{ display:flex; gap:16px; align-items:center }
-    .brand img{ width:80px; height:80px; object-fit:cover; border-radius:50%; border:1px solid var(--border) }
-    .brand h1{ margin:0; font-size:clamp(22px,3vw,30px) }
-    .badge{ display:inline-block; padding:2px 8px; border:1px solid var(--border); border-radius:999px; font-size:12px; color:var(--muted); margin-left:8px }
-    nav{ border-top:1px solid var(--border); border-bottom:1px solid var(--border); background:var(--card) }
-    nav .row{ max-width:1000px; margin:auto; padding:10px 20px; display:flex; gap:12px; flex-wrap:wrap }
-    nav a{ text-decoration:none; color:var(--fg); padding:6px 10px; border-radius:8px }
-    nav a:hover{ background:var(--border) }
-    main{ max-width:1000px; margin:auto; padding:28px 20px; display:grid; gap:24px }
-    section{ padding:18px; border:1px solid var(--border); border-radius:14px; background:var(--card) }
-    h2{ margin:0 0 8px; font-size:1.25rem }
-    h3{ margin:0 0 6px; font-size:1.05rem }
-    ul{ margin:8px 0; padding-left:18px }
-    .muted{ color:var(--muted) }
-    footer{ border-top:1px solid var(--border); color:var(--muted); text-align:center; padding:20px }
-  </style>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Libre+Baskerville:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
 </head>
 <body>
   <header>
-    <div class="brand">
-      <img src="https://github.com/Mar1aFede.png" alt="Portrait of Maria Federica Norelli" />
-      <div>
-        <h1>Talks — Maria Federica Norelli <span class="badge">PhD Candidate</span></h1>
-        <p class="muted"><a href="index.html">← Home</a></p>
+    <div class="container">
+      <div class="brand">
+        <img src="https://github.com/Mar1aFede.png" alt="Portrait of Maria Federica Norelli" />
+        <div>
+          <h1 class="title">Talks — Maria Federica Norelli <span class="badge">PhD Candidate</span></h1>
+          <p class="muted"><a href="index.html">← Home</a></p>
+        </div>
       </div>
     </div>
   </header>
 
-  <nav>
+  <nav class="sticky">
     <div class="row">
       <a href="index.html#about">Home</a>
       <a href="research.html">Research</a>
@@ -53,52 +37,41 @@
   </nav>
 
   <main>
-    <section>
-      <h2>2025</h2>
-      <ul>
-        <li><strong>Amplifying Humanities Research with AI and Network Science Methods</strong>, Workshop — NU London (London), <em>7 May 2025</em> — speaker. <!-- CV --> </li>
-        <li><strong>Sparsity, Generalization, and Winning Tickets of Deep Neural Networks: The Noise-Cancelling Razor of Machine Learning</strong>, <em>10th Biennial Meeting of the European Philosophy of Science Association (EPSA)</em> — Groningen, Netherlands, <em>27–30 Aug 2025</em> — speaker. <!-- CV --> </li>
-      </ul>
-    </section>
+    <div class="container">
+      <section class="card">
+        <h2 class="subtitle">2025</h2>
+        <ul>
+          <li><strong>Amplifying Humanities Research with AI and Network Science Methods</strong>, Workshop — NU London (London), <em>7 May 2025</em> — speaker. <!-- CV --> </li>
+          <li><strong>Sparsity, Generalization, and Winning Tickets of Deep Neural Networks: The Noise-Cancelling Razor of Machine Learning</strong>, <em>10th Biennial Meeting of the European Philosophy of Science Association (EPSA)</em> — Groningen, Netherlands, <em>27–30 Aug 2025</em> — speaker. <!-- CV --> </li>
+        </ul>
+      </section>
 
-    <section>
-      <h2>2024</h2>
-      <ul>
-        <li><strong>The Interplay of Data, Phenomena and Models</strong>, <em>29th Biennial Meeting of the Philosophy of Science Association (PSA 2024)</em> — New Orleans, USA, <em>14–17 Nov 2024</em> — speaker. <!-- CV --> </li>
-        <li><strong>Human and Network Sciences Bootcamp</strong> — NU London (London), <em>Oct 2024</em> — speaker. <!-- CV --> </li>
-        <li><strong>AI in Action Bootcamp</strong> — NU London (London), <em>May 2024</em> — speaker. <!-- CV --> </li>
-        <li><strong>Addressing Contemporary Human Security Threats: Conversations on Climate, Conflict, Technology, Identity, and Health</strong>, PhD Symposium — NU London (London), <em>May 2024</em> — poster presenter. <!-- CV --> </li>
-        <li><strong>Theoretical Reasoning Research Cluster</strong> — Centre for Reasoning, University of Kent (Canterbury), <em>Mar 2024</em> — speaker. <!-- CV --> </li>
-      </ul>
-    </section>
+      <section class="card">
+        <h2 class="subtitle">2024</h2>
+        <ul>
+          <li><strong>The Interplay of Data, Phenomena and Models</strong>, <em>29th Biennial Meeting of the Philosophy of Science Association (PSA 2024)</em> — New Orleans, USA, <em>14–17 Nov 2024</em> — speaker. <!-- CV --> </li>
+          <li><strong>Human and Network Sciences Bootcamp</strong> — NU London (London), <em>Oct 2024</em> — speaker. <!-- CV --> </li>
+          <li><strong>AI in Action Bootcamp</strong> — NU London (London), <em>May 2024</em> — speaker. <!-- CV --> </li>
+          <li><strong>Addressing Contemporary Human Security Threats: Conversations on Climate, Conflict, Technology, Identity, and Health</strong>, PhD Symposium — NU London (London), <em>May 2024</em> — poster presenter. <!-- CV --> </li>
+          <li><strong>Theoretical Reasoning Research Cluster</strong> — Centre for Reasoning, University of Kent (Canterbury), <em>Mar 2024</em> — speaker. <!-- CV --> </li>
+        </ul>
+      </section>
 
-    <section>
-      <h2>2023</h2>
-      <ul>
-        <li><strong>The Use of Colour Names Over Repeated Trials</strong>, <em>CdC Color Conference</em> — Gruppo del Colore, Lecco (Lake Como), Italy, <em>15–16 Sep 2023</em> — speaker. <!-- CV --> </li>
-        <li><strong>Data, Phenomena and Models in Machine Learning</strong>, <em>5th “Philosophy of Artificial Intelligence” (Society for the Philosophy of AI)</em> — Erlangen, Germany, <em>15–16 Dec 2023</em> — poster presenter. <!-- CV --> </li>
-      </ul>
-    </section>
-
-    <section>
-      <h2>2022</h2>
-      <ul>
-        <li><strong>Cultural Differences in the Cognitive Aspects of Colour Geometry</strong>, <em>Wittgenstein and AI — 11th British Wittgenstein Society Conference</em>, New College of the Humanities (London), <em>29–31 Jul 2022</em> — speaker. <!-- CV --> </li>
-      </ul>
-    </section>
-
-    <section>
-      <h2>2021</h2>
-      <ul>
-        <li><strong>Democrazia e Opinione Pubblica. Cos’è la Post-Verità?</strong>, <em>Dialoghi Etici</em>, patrocinio del Comune di Contursi Terme (SA), <em>24 Apr 2021</em> — speaker. <!-- CV --> </li>
-      </ul>
-    </section>
+      <section class="card">
+        <h2 class="subtitle">2023</h2>
+        <ul>
+          <li><strong>The Use of Colour Names Over Repeated Trials</strong>, <em>CdC Color Conference</em> — Gruppo del Colore, Lecco (Lake Como), Italy, <em>15–16 Sep 2023</em> — speaker. <!-- CV --> </li>
+          <li><strong>Data, Phenomena and Models in Machine Learning</strong>, <em>5th “Philosophy of Artificial Intelligence” (Society for the Philosophy of AI)</em> — Erlangen, Germany, <em>15–16 Dec 2023</em> — poster presenter. <!-- CV --> </li>
+        </ul>
+      </section>
+    </div>
   </main>
 
   <footer>
-    © <span id="y"></span> Maria Federica Norelli · Hosted on GitHub Pages
+    <div class="container">
+      © <span id="y"></span> Maria Federica Norelli · Hosted on GitHub Pages
+    </div>
   </footer>
   <script>document.getElementById('y').textContent = new Date().getFullYear();</script>
 </body>
 </html>
-


### PR DESCRIPTION
## Summary
- centralize site styling in new `styles.css` with color variables, dark-mode gradients, typography, card layout, and sticky navigation utilities
- switch all pages to reference the shared stylesheet and Google Fonts instead of inline styles
- wrap content in `.container`, apply `.card` sections, and update headings and navigation classes across the site

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b72e5dd2208326870e2c780428b1ef