### PR TITLE
Use Lora font sitewide

### DIFF
--- a/cv.html
+++ b/cv.html
@@ -9,11 +9,12 @@
   <meta name="color-scheme" content="light dark">
 <link rel="icon" href="assets/logo.webp" type="image/webp">
 <link rel="icon" href="assets/logo.webp" type="image/webp">
+  <link href="https://fonts.googleapis.com/css2?family=Lora:wght@400;700&display=swap" rel="stylesheet">
   <style>
     :root { --bg:#ffffff; --fg:#0f172a; --muted:#64748b; --link:#1f6feb; --card:#f8fafc; --border:#e2e8f0; }
     @media (prefers-color-scheme: dark){ :root{ --bg:#0b0f14; --fg:#e6edf3; --muted:#9aa4af; --card:#0f141b; --border:#1f2937; } }
     *{ box-sizing:border-box }
-    body{ margin:0; font-family:ui-sans-serif,-apple-system,system-ui,Segoe UI,Roboto,Helvetica,Arial; background:var(--bg); color:var(--fg); line-height:1.6 }
+    body{ margin:0; font-family:'Lora', serif; background:var(--bg); color:var(--fg); line-height:1.6 }
     a{ color:var(--link) }
     header{ max-width:1000px; margin:auto; padding:48px 20px; display:flex; gap:24px; align-items:center }
     header img{ width:110px; height:110px; object-fit:cover; border-radius:50%; border:1px solid var(--border) }

--- a/experience.html
+++ b/experience.html
@@ -9,11 +9,12 @@
   <meta name="color-scheme" content="light dark">
 <link rel="icon" href="assets/logo.webp" type="image/webp">
 <link rel="icon" href="assets/logo.webp" type="image/webp">
+  <link href="https://fonts.googleapis.com/css2?family=Lora:wght@400;700&display=swap" rel="stylesheet">
   <style>
     :root { --bg:#ffffff; --fg:#0f172a; --muted:#64748b; --link:#1f6feb; --card:#f8fafc; --border:#e2e8f0; }
     @media (prefers-color-scheme: dark){ :root{ --bg:#0b0f14; --fg:#e6edf3; --muted:#9aa4af; --card:#0f141b; --border:#1f2937; } }
     *{ box-sizing:border-box }
-    body{ margin:0; font-family:ui-sans-serif,-apple-system,system-ui,Segoe UI,Roboto,Helvetica,Arial; background:var(--bg); color:var(--fg); line-height:1.6 }
+    body{ margin:0; font-family:'Lora', serif; background:var(--bg); color:var(--fg); line-height:1.6 }
     a{ color:var(--link) }
     header{ max-width:1000px; margin:auto; padding:48px 20px; display:flex; gap:24px; align-items:center }
     header img{ width:110px; height:110px; object-fit:cover; border-radius:50%; border:1px solid var(--border) }

--- a/index.html
+++ b/index.html
@@ -9,11 +9,12 @@
   <meta name="color-scheme" content="light dark">
 <link rel="icon" href="assets/logo.webp" type="image/webp">
 <link rel="icon" href="assets/logo.webp" type="image/webp">
+  <link href="https://fonts.googleapis.com/css2?family=Lora:wght@400;700&display=swap" rel="stylesheet">
   <style>
     :root { --bg:#ffffff; --fg:#0f172a; --muted:#64748b; --link:#1f6feb; --card:#f8fafc; --border:#e2e8f0; }
     @media (prefers-color-scheme: dark){ :root{ --bg:#0b0f14; --fg:#e6edf3; --muted:#9aa4af; --card:#0f141b; --border:#1f2937; } }
     *{ box-sizing:border-box }
-    body{ margin:0; font-family:ui-sans-serif,-apple-system,system-ui,Segoe UI,Roboto,Helvetica,Arial; background:var(--bg); color:var(--fg); line-height:1.6 }
+    body{ margin:0; font-family:'Lora', serif; background:var(--bg); color:var(--fg); line-height:1.6 }
     a{ color:var(--link) }
     header{ max-width:1000px; margin:auto; padding:48px 20px; display:flex; gap:24px; align-items:center }
     header img{ width:110px; height:110px; object-fit:cover; border-radius:50%; border:1px solid var(--border) }

--- a/publications.html
+++ b/publications.html
@@ -9,11 +9,12 @@
   <meta name="color-scheme" content="light dark">
 <link rel="icon" href="assets/logo.webp" type="image/webp">
 <link rel="icon" href="assets/logo.webp" type="image/webp">
+  <link href="https://fonts.googleapis.com/css2?family=Lora:wght@400;700&display=swap" rel="stylesheet">
   <style>
     :root { --bg:#ffffff; --fg:#0f172a; --muted:#64748b; --link:#1f6feb; --card:#f8fafc; --border:#e2e8f0; }
     @media (prefers-color-scheme: dark){ :root{ --bg:#0b0f14; --fg:#e6edf3; --muted:#9aa4af; --card:#0f141b; --border:#1f2937; } }
     *{ box-sizing:border-box }
-    body{ margin:0; font-family:ui-sans-serif,-apple-system,system-ui,Segoe UI,Roboto,Helvetica,Arial; background:var(--bg); color:var(--fg); line-height:1.6 }
+    body{ margin:0; font-family:'Lora', serif; background:var(--bg); color:var(--fg); line-height:1.6 }
     a{ color:var(--link) }
     header{ max-width:1000px; margin:auto; padding:48px 20px; display:flex; gap:24px; align-items:center }
     header img{ width:110px; height:110px; object-fit:cover; border-radius:50%; border:1px solid var(--border) }

--- a/research.html
+++ b/research.html
@@ -9,11 +9,12 @@
   <meta name="color-scheme" content="light dark">
 <link rel="icon" href="assets/logo.webp" type="image/webp">
 <link rel="icon" href="assets/logo.webp" type="image/webp">
+  <link href="https://fonts.googleapis.com/css2?family=Lora:wght@400;700&display=swap" rel="stylesheet">
   <style>
     :root { --bg:#ffffff; --fg:#0f172a; --muted:#64748b; --link:#1f6feb; --card:#f8fafc; --border:#e2e8f0; }
     @media (prefers-color-scheme: dark){ :root{ --bg:#0b0f14; --fg:#e6edf3; --muted:#9aa4af; --card:#0f141b; --border:#1f2937; } }
     *{ box-sizing:border-box }
-    body{ margin:0; font-family:ui-sans-serif,-apple-system,system-ui,Segoe UI,Roboto,Helvetica,Arial; background:var(--bg); color:var(--fg); line-height:1.6 }
+    body{ margin:0; font-family:'Lora', serif; background:var(--bg); color:var(--fg); line-height:1.6 }
     a{ color:var(--link) }
     header{ max-width:1000px; margin:auto; padding:48px 20px; display:flex; gap:24px; align-items:center }
     header img{ width:110px; height:110px; object-fit:cover; border-radius:50%; border:1px solid var(--border) }

--- a/talks.html
+++ b/talks.html
@@ -9,11 +9,12 @@
   <meta name="color-scheme" content="light dark">
 <link rel="icon" href="assets/logo.webp" type="image/webp">
 <link rel="icon" href="assets/logo.webp" type="image/webp">
+  <link href="https://fonts.googleapis.com/css2?family=Lora:wght@400;700&display=swap" rel="stylesheet">
   <style>
     :root { --bg:#ffffff; --fg:#0f172a; --muted:#64748b; --link:#1f6feb; --card:#f8fafc; --border:#e2e8f0; }
     @media (prefers-color-scheme: dark){ :root{ --bg:#0b0f14; --fg:#e6edf3; --muted:#9aa4af; --card:#0f141b; --border:#1f2937; } }
     *{ box-sizing:border-box }
-    body{ margin:0; font-family:ui-sans-serif,-apple-system,system-ui,Segoe UI,Roboto,Helvetica,Arial; background:var(--bg); color:var(--fg); line-height:1.6 }
+    body{ margin:0; font-family:'Lora', serif; background:var(--bg); color:var(--fg); line-height:1.6 }
     a{ color:var(--link) }
     header{ max-width:1000px; margin:auto; padding:48px 20px; display:flex; gap:24px; align-items:center }
     header img{ width:110px; height:110px; object-fit:cover; border-radius:50%; border:1px solid var(--border) }


### PR DESCRIPTION
## Summary
- Load Lora from Google Fonts on every page
- Set the body font to 'Lora', serif to ensure consistent typography

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b82cdabad883268b856777c42160fd