### PR TITLE
feat: refresh site color palette

### DIFF
--- a/cv.html
+++ b/cv.html
@@ -11,7 +11,7 @@
 <link rel="icon" href="assets/logo.webp" type="image/webp">
   <style>
     :root { --bg:#ffffff; --fg:#0f172a; --muted:#64748b; --link:#1f6feb; --card:#f8fafc; --border:#e2e8f0; }
-    @media (prefers-color-scheme: dark){ :root{ --bg:#0b0f14; --fg:#e6edf3; --muted:#9aa4af; --card:#0f141b; --border:#1f2937; } }
+    @media (prefers-color-scheme: dark){ :root{ --bg:#0b0f14; --fg:#e6edf3; --muted:#9aa4af; --link:#2f81f7; --card:#161b22; --border:#1f2937; } }
     *{ box-sizing:border-box }
     body{ margin:0; font-family:ui-sans-serif,-apple-system,system-ui,Segoe UI,Roboto,Helvetica,Arial; background:var(--bg); color:var(--fg); line-height:1.6 }
     a{ color:var(--link) }

--- a/experience.html
+++ b/experience.html
@@ -11,7 +11,7 @@
 <link rel="icon" href="assets/logo.webp" type="image/webp">
   <style>
     :root { --bg:#ffffff; --fg:#0f172a; --muted:#64748b; --link:#1f6feb; --card:#f8fafc; --border:#e2e8f0; }
-    @media (prefers-color-scheme: dark){ :root{ --bg:#0b0f14; --fg:#e6edf3; --muted:#9aa4af; --card:#0f141b; --border:#1f2937; } }
+    @media (prefers-color-scheme: dark){ :root{ --bg:#0b0f14; --fg:#e6edf3; --muted:#9aa4af; --link:#2f81f7; --card:#161b22; --border:#1f2937; } }
     *{ box-sizing:border-box }
     body{ margin:0; font-family:ui-sans-serif,-apple-system,system-ui,Segoe UI,Roboto,Helvetica,Arial; background:var(--bg); color:var(--fg); line-height:1.6 }
     a{ color:var(--link) }

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 <link rel="icon" href="assets/logo.webp" type="image/webp">
   <style>
     :root { --bg:#ffffff; --fg:#0f172a; --muted:#64748b; --link:#1f6feb; --card:#f8fafc; --border:#e2e8f0; }
-    @media (prefers-color-scheme: dark){ :root{ --bg:#0b0f14; --fg:#e6edf3; --muted:#9aa4af; --card:#0f141b; --border:#1f2937; } }
+    @media (prefers-color-scheme: dark){ :root{ --bg:#0b0f14; --fg:#e6edf3; --muted:#9aa4af; --link:#2f81f7; --card:#161b22; --border:#1f2937; } }
     *{ box-sizing:border-box }
     body{ margin:0; font-family:ui-sans-serif,-apple-system,system-ui,Segoe UI,Roboto,Helvetica,Arial; background:var(--bg); color:var(--fg); line-height:1.6 }
     a{ color:var(--link) }

--- a/publications.html
+++ b/publications.html
@@ -11,7 +11,7 @@
 <link rel="icon" href="assets/logo.webp" type="image/webp">
   <style>
     :root { --bg:#ffffff; --fg:#0f172a; --muted:#64748b; --link:#1f6feb; --card:#f8fafc; --border:#e2e8f0; }
-    @media (prefers-color-scheme: dark){ :root{ --bg:#0b0f14; --fg:#e6edf3; --muted:#9aa4af; --card:#0f141b; --border:#1f2937; } }
+    @media (prefers-color-scheme: dark){ :root{ --bg:#0b0f14; --fg:#e6edf3; --muted:#9aa4af; --link:#2f81f7; --card:#161b22; --border:#1f2937; } }
     *{ box-sizing:border-box }
     body{ margin:0; font-family:ui-sans-serif,-apple-system,system-ui,Segoe UI,Roboto,Helvetica,Arial; background:var(--bg); color:var(--fg); line-height:1.6 }
     a{ color:var(--link) }

--- a/research.html
+++ b/research.html
@@ -11,7 +11,7 @@
 <link rel="icon" href="assets/logo.webp" type="image/webp">
   <style>
     :root { --bg:#ffffff; --fg:#0f172a; --muted:#64748b; --link:#1f6feb; --card:#f8fafc; --border:#e2e8f0; }
-    @media (prefers-color-scheme: dark){ :root{ --bg:#0b0f14; --fg:#e6edf3; --muted:#9aa4af; --card:#0f141b; --border:#1f2937; } }
+    @media (prefers-color-scheme: dark){ :root{ --bg:#0b0f14; --fg:#e6edf3; --muted:#9aa4af; --link:#2f81f7; --card:#161b22; --border:#1f2937; } }
     *{ box-sizing:border-box }
     body{ margin:0; font-family:ui-sans-serif,-apple-system,system-ui,Segoe UI,Roboto,Helvetica,Arial; background:var(--bg); color:var(--fg); line-height:1.6 }
     a{ color:var(--link) }

--- a/talks.html
+++ b/talks.html
@@ -11,7 +11,7 @@
 <link rel="icon" href="assets/logo.webp" type="image/webp">
   <style>
     :root { --bg:#ffffff; --fg:#0f172a; --muted:#64748b; --link:#1f6feb; --card:#f8fafc; --border:#e2e8f0; }
-    @media (prefers-color-scheme: dark){ :root{ --bg:#0b0f14; --fg:#e6edf3; --muted:#9aa4af; --card:#0f141b; --border:#1f2937; } }
+    @media (prefers-color-scheme: dark){ :root{ --bg:#0b0f14; --fg:#e6edf3; --muted:#9aa4af; --link:#2f81f7; --card:#161b22; --border:#1f2937; } }
     *{ box-sizing:border-box }
     body{ margin:0; font-family:ui-sans-serif,-apple-system,system-ui,Segoe UI,Roboto,Helvetica,Arial; background:var(--bg); color:var(--fg); line-height:1.6 }
     a{ color:var(--link) }


### PR DESCRIPTION
## Summary
- restyle site with neutral palette and dark-mode complements
- ensure link and card colors maintain contrast in light and dark themes

## Testing
- `npm test` *(fails: ENOENT cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b82ce2047c83268485518c09871b6b