### PR TITLE
feat: refresh color palette with lavender cards and magenta borders

### DIFF
--- a/cv.html
+++ b/cv.html
@@ -8,8 +8,8 @@
   <meta name="color-scheme" content="light dark">
   <link href="https://fonts.googleapis.com/css2?family=Lora:wght@400;700&display=swap" rel="stylesheet">
   <style>
-    :root { --bg:#f0f4f8; --fg:#1e293b; --muted:#64748b; --link:#3b82f6; --card:#e2e8f0; --border:#cbd5e1; }
-    @media (prefers-color-scheme: dark){ :root{ --bg:#0f172a; --fg:#f1f5f9; --muted:#94a3b8; --link:#93c5fd; --card:#1e293b; --border:#334155; } }
+    :root { --bg:#f0f4f8; --fg:#000; --muted:#64748b; --link:#3b82f6; --card:#e6e6fa; --border:#ff00ff; }
+    @media (prefers-color-scheme: dark){ :root{ --bg:#0f172a; --fg:#f1f5f9; --muted:#94a3b8; --link:#93c5fd; --card:#2e1065; --border:#c026d3; } }
     *{ box-sizing:border-box }
     body{ margin:0; font-family:'Lora', serif; background:var(--bg); color:var(--fg); line-height:1.6 }
     a{ color:var(--link) }

--- a/experience.html
+++ b/experience.html
@@ -8,8 +8,8 @@
   <meta name="color-scheme" content="light dark">
   <link href="https://fonts.googleapis.com/css2?family=Lora:wght@400;700&display=swap" rel="stylesheet">
   <style>
-    :root { --bg:#f0f4f8; --fg:#1e293b; --muted:#64748b; --link:#3b82f6; --card:#e2e8f0; --border:#cbd5e1; }
-    @media (prefers-color-scheme: dark){ :root{ --bg:#0f172a; --fg:#f1f5f9; --muted:#94a3b8; --link:#93c5fd; --card:#1e293b; --border:#334155; } }
+    :root { --bg:#f0f4f8; --fg:#000; --muted:#64748b; --link:#3b82f6; --card:#e6e6fa; --border:#ff00ff; }
+    @media (prefers-color-scheme: dark){ :root{ --bg:#0f172a; --fg:#f1f5f9; --muted:#94a3b8; --link:#93c5fd; --card:#2e1065; --border:#c026d3; } }
     *{ box-sizing:border-box }
     body{ margin:0; font-family:'Lora', serif; background:var(--bg); color:var(--fg); line-height:1.6 }
     a{ color:var(--link) }

--- a/index.html
+++ b/index.html
@@ -8,8 +8,8 @@
   <meta name="color-scheme" content="light dark">
   <link href="https://fonts.googleapis.com/css2?family=Lora:wght@400;700&display=swap" rel="stylesheet">
   <style>
-    :root { --bg:#f0f4f8; --fg:#1e293b; --muted:#64748b; --link:#3b82f6; --card:#e2e8f0; --border:#cbd5e1; }
-    @media (prefers-color-scheme: dark){ :root{ --bg:#0f172a; --fg:#f1f5f9; --muted:#94a3b8; --link:#93c5fd; --card:#1e293b; --border:#334155; } }
+    :root { --bg:#f0f4f8; --fg:#000; --muted:#64748b; --link:#3b82f6; --card:#e6e6fa; --border:#ff00ff; }
+    @media (prefers-color-scheme: dark){ :root{ --bg:#0f172a; --fg:#f1f5f9; --muted:#94a3b8; --link:#93c5fd; --card:#2e1065; --border:#c026d3; } }
     *{ box-sizing:border-box }
     body{ margin:0; font-family:'Lora', serif; background:var(--bg); color:var(--fg); line-height:1.6 }
     a{ color:var(--link) }

--- a/publications.html
+++ b/publications.html
@@ -8,8 +8,8 @@
   <meta name="color-scheme" content="light dark">
   <link href="https://fonts.googleapis.com/css2?family=Lora:wght@400;700&display=swap" rel="stylesheet">
   <style>
-    :root { --bg:#f0f4f8; --fg:#1e293b; --muted:#64748b; --link:#3b82f6; --card:#e2e8f0; --border:#cbd5e1; }
-    @media (prefers-color-scheme: dark){ :root{ --bg:#0f172a; --fg:#f1f5f9; --muted:#94a3b8; --link:#93c5fd; --card:#1e293b; --border:#334155; } }
+    :root { --bg:#f0f4f8; --fg:#000; --muted:#64748b; --link:#3b82f6; --card:#e6e6fa; --border:#ff00ff; }
+    @media (prefers-color-scheme: dark){ :root{ --bg:#0f172a; --fg:#f1f5f9; --muted:#94a3b8; --link:#93c5fd; --card:#2e1065; --border:#c026d3; } }
     *{ box-sizing:border-box }
     body{ margin:0; font-family:'Lora', serif; background:var(--bg); color:var(--fg); line-height:1.6 }
     a{ color:var(--link) }

--- a/research.html
+++ b/research.html
@@ -8,8 +8,8 @@
   <meta name="color-scheme" content="light dark">
   <link href="https://fonts.googleapis.com/css2?family=Lora:wght@400;700&display=swap" rel="stylesheet">
   <style>
-    :root { --bg:#f0f4f8; --fg:#1e293b; --muted:#64748b; --link:#3b82f6; --card:#e2e8f0; --border:#cbd5e1; }
-    @media (prefers-color-scheme: dark){ :root{ --bg:#0f172a; --fg:#f1f5f9; --muted:#94a3b8; --link:#93c5fd; --card:#1e293b; --border:#334155; } }
+    :root { --bg:#f0f4f8; --fg:#000; --muted:#64748b; --link:#3b82f6; --card:#e6e6fa; --border:#ff00ff; }
+    @media (prefers-color-scheme: dark){ :root{ --bg:#0f172a; --fg:#f1f5f9; --muted:#94a3b8; --link:#93c5fd; --card:#2e1065; --border:#c026d3; } }
     *{ box-sizing:border-box }
     body{ margin:0; font-family:'Lora', serif; background:var(--bg); color:var(--fg); line-height:1.6 }
     a{ color:var(--link) }

--- a/talks.html
+++ b/talks.html
@@ -8,8 +8,8 @@
   <meta name="color-scheme" content="light dark">
   <link href="https://fonts.googleapis.com/css2?family=Lora:wght@400;700&display=swap" rel="stylesheet">
   <style>
-    :root { --bg:#f0f4f8; --fg:#1e293b; --muted:#64748b; --link:#3b82f6; --card:#e2e8f0; --border:#cbd5e1; }
-    @media (prefers-color-scheme: dark){ :root{ --bg:#0f172a; --fg:#f1f5f9; --muted:#94a3b8; --link:#93c5fd; --card:#1e293b; --border:#334155; } }
+    :root { --bg:#f0f4f8; --fg:#000; --muted:#64748b; --link:#3b82f6; --card:#e6e6fa; --border:#ff00ff; }
+    @media (prefers-color-scheme: dark){ :root{ --bg:#0f172a; --fg:#f1f5f9; --muted:#94a3b8; --link:#93c5fd; --card:#2e1065; --border:#c026d3; } }
     *{ box-sizing:border-box }
     body{ margin:0; font-family:'Lora', serif; background:var(--bg); color:var(--fg); line-height:1.6 }
     a{ color:var(--link) }


### PR DESCRIPTION
## Summary
- restore black default text and lavender card backgrounds
- switch borders to magenta with dark-mode complements
- ensure section containers use new --card and --border variables across pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b851d89b3083268a7271b4b6bfab40