### PR TITLE
Add blurred background and larger headings

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -3,5 +3,18 @@
 
 /* Background art */
 body.bg-art{ background: var(--bg); }
-body.bg-art::before{ content:""; position:fixed; inset:0; z-index:-1; background:url("assets/website_image.webp") center/cover no-repeat; opacity:.35; pointer-events:none; }
+body.bg-art::before{
+  content:"";
+  position:fixed;
+  inset:0;
+  z-index:-1;
+  background:url("website_image.webp") center/cover no-repeat;
+  opacity:.35;
+  pointer-events:none;
+  filter:blur(5px);
+}
 @media (prefers-color-scheme: dark){ body.bg-art::before{ opacity:.40; } }
+
+/* Larger headings */
+header h1{ font-size:clamp(28px,5vw,48px); }
+h2{ font-size:1.5rem; }


### PR DESCRIPTION
## Summary
- Blur background art and ensure site uses `website_image.webp`
- Enlarge h1 and h2 headings across pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b85462f468832689c57b719f07be78