### PR TITLE
Use absolute stylesheet path

### DIFF
--- a/cv.html
+++ b/cv.html
@@ -23,7 +23,7 @@
     h2{ margin:0 0 8px; font-size:1.25rem }
     footer{ border-top:1px solid var(--border); color:var(--muted); text-align:center; padding:20px }
   </style>
-<link rel="stylesheet" href="assets/style.css">
+<link rel="stylesheet" href="/assets/style.css">
 <link rel="icon" href="/favicon.ico" sizes="any">
 <link rel="icon" sizes="32x32" href="assets/favicon-32.png" type="image/png">
 <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">

--- a/experience.html
+++ b/experience.html
@@ -23,7 +23,7 @@
     h2{ margin:0 0 8px; font-size:1.25rem }
     footer{ border-top:1px solid var(--border); color:var(--muted); text-align:center; padding:20px }
   </style>
-<link rel="stylesheet" href="assets/style.css">
+<link rel="stylesheet" href="/assets/style.css">
 <link rel="icon" href="/favicon.ico" sizes="any">
 <link rel="icon" sizes="32x32" href="assets/favicon-32.png" type="image/png">
 <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
     h2{ margin:0 0 8px; font-size:1.25rem }
     footer{ border-top:1px solid var(--border); color:var(--muted); text-align:center; padding:20px }
   </style>
-<link rel="stylesheet" href="assets/style.css">
+<link rel="stylesheet" href="/assets/style.css">
 <link rel="icon" href="/favicon.ico" sizes="any">
 <link rel="icon" sizes="32x32" href="assets/favicon-32.png" type="image/png">
 <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">

--- a/publications.html
+++ b/publications.html
@@ -23,7 +23,7 @@
     h2{ margin:0 0 8px; font-size:1.25rem }
     footer{ border-top:1px solid var(--border); color:var(--muted); text-align:center; padding:20px }
   </style>
-<link rel="stylesheet" href="assets/style.css">
+<link rel="stylesheet" href="/assets/style.css">
 <link rel="icon" href="/favicon.ico" sizes="any">
 <link rel="icon" sizes="32x32" href="assets/favicon-32.png" type="image/png">
 <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">

--- a/research.html
+++ b/research.html
@@ -23,7 +23,7 @@
     h2{ margin:0 0 8px; font-size:1.25rem }
     footer{ border-top:1px solid var(--border); color:var(--muted); text-align:center; padding:20px }
   </style>
-<link rel="stylesheet" href="assets/style.css">
+<link rel="stylesheet" href="/assets/style.css">
 <link rel="icon" href="/favicon.ico" sizes="any">
 <link rel="icon" sizes="32x32" href="assets/favicon-32.png" type="image/png">
 <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">

--- a/talks.html
+++ b/talks.html
@@ -23,7 +23,7 @@
     h2{ margin:0 0 8px; font-size:1.25rem }
     footer{ border-top:1px solid var(--border); color:var(--muted); text-align:center; padding:20px }
   </style>
-<link rel="stylesheet" href="assets/style.css">
+<link rel="stylesheet" href="/assets/style.css">
 <link rel="icon" href="/favicon.ico" sizes="any">
 <link rel="icon" sizes="32x32" href="assets/favicon-32.png" type="image/png">
 <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">


### PR DESCRIPTION
## Summary
- Use an absolute `/assets/style.css` path in root HTML pages so styles and background images load correctly from subdirectories.

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b857b5b98c83269b4f02bd34eda1ee