### PR TITLE
Remove redundant Home link from internal pages

### DIFF
--- a/cv.html
+++ b/cv.html
@@ -40,7 +40,6 @@
     <img src="https://github.com/Mar1aFede.png" alt="Portrait of Maria Federica Norelli">
     <div>
       <h1>CV — Maria Federica Norelli</h1>
-      <p><a href="index.html">← Home</a></p>
     </div>
   </header>
 

--- a/experience.html
+++ b/experience.html
@@ -40,7 +40,6 @@
     <img src="https://github.com/Mar1aFede.png" alt="Portrait of Maria Federica Norelli">
     <div>
       <h1>Experience — Maria Federica Norelli</h1>
-      <p><a href="index.html">← Home</a></p>
     </div>
   </header>
 

--- a/publications.html
+++ b/publications.html
@@ -40,7 +40,6 @@
     <img src="https://github.com/Mar1aFede.png" alt="Portrait of Maria Federica Norelli">
     <div>
       <h1>Publications — Maria Federica Norelli</h1>
-      <p><a href="index.html">← Home</a></p>
     </div>
   </header>
 

--- a/research.html
+++ b/research.html
@@ -40,7 +40,6 @@
     <img src="https://github.com/Mar1aFede.png" alt="Portrait of Maria Federica Norelli">
     <div>
       <h1>Research — Maria Federica Norelli</h1>
-      <p><a href="index.html">← Home</a></p>
     </div>
   </header>
 

--- a/talks.html
+++ b/talks.html
@@ -40,7 +40,6 @@
     <img src="https://github.com/Mar1aFede.png" alt="Portrait of Maria Federica Norelli">
     <div>
       <h1>Talks — Maria Federica Norelli</h1>
-      <p><a href="index.html">← Home</a></p>
     </div>
   </header>
 


### PR DESCRIPTION
## Summary
- Remove duplicate Home navigation link from headers of CV, Experience, Publications, Research, and Talks pages

## Testing
- `python -m http.server 8000`
- `curl -L http://localhost:8000/cv.html | head -n 20`
- `curl -L http://localhost:8000/experience.html | head -n 20`
- `curl -L http://localhost:8000/publications.html | head -n 20`
- `curl -L http://localhost:8000/research.html | head -n 20`
- `curl -L http://localhost:8000/talks.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68bb86f4673483269e1f62027b744a7d