### PR TITLE
Rename Talks section to Talks/Workshops

### DIFF
--- a/cv.html
+++ b/cv.html
@@ -48,7 +48,7 @@
     <a href="research.html">Research</a>
     <a href="experience.html">Experience</a>
     <a href="publications.html">Publications</a>
-    <a href="talks.html">Talks</a>
+    <a href="talks.html">Talks/Workshops</a>
     <a href="cv.html">CV</a>
   </nav>
 

--- a/experience.html
+++ b/experience.html
@@ -48,7 +48,7 @@
     <a href="research.html">Research</a>
     <a href="experience.html">Experience</a>
     <a href="publications.html">Publications</a>
-    <a href="talks.html">Talks</a>
+    <a href="talks.html">Talks/Workshops</a>
     <a href="cv.html">CV</a>
   </nav>
 

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
     <a href="research.html">Research</a>
     <a href="experience.html">Experience</a>
     <a href="publications.html">Publications</a>
-    <a href="talks.html">Talks</a>
+    <a href="talks.html">Talks/Workshops</a>
     <a href="cv.html">CV</a>
   </nav>
 

--- a/publications.html
+++ b/publications.html
@@ -48,7 +48,7 @@
     <a href="research.html">Research</a>
     <a href="experience.html">Experience</a>
     <a href="publications.html">Publications</a>
-    <a href="talks.html">Talks</a>
+    <a href="talks.html">Talks/Workshops</a>
     <a href="cv.html">CV</a>
   </nav>
 

--- a/research.html
+++ b/research.html
@@ -48,7 +48,7 @@
     <a href="research.html">Research</a>
     <a href="experience.html">Experience</a>
     <a href="publications.html">Publications</a>
-    <a href="talks.html">Talks</a>
+    <a href="talks.html">Talks/Workshops</a>
     <a href="cv.html">CV</a>
   </nav>
 

--- a/talks.html
+++ b/talks.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Talks and Workshops — Maria Federica Norelli</title>
+  <title>Talks/Workshops — Maria Federica Norelli</title>
   <meta name="color-scheme" content="light dark">
   <link href="https://fonts.googleapis.com/css2?family=Lora:wght@400;700&display=swap" rel="stylesheet">
   <style>
@@ -39,7 +39,7 @@
   <header>
     <img src="https://github.com/Mar1aFede.png" alt="Portrait of Maria Federica Norelli">
     <div>
-      <h1>Talks — Maria Federica Norelli</h1>
+      <h1>Talks/Workshops — Maria Federica Norelli</h1>
     </div>
   </header>
 
@@ -48,7 +48,7 @@
     <a href="research.html">Research</a>
     <a href="experience.html">Experience</a>
     <a href="publications.html">Publications</a>
-    <a href="talks.html">Talks</a>
+    <a href="talks.html">Talks/Workshops</a>
     <a href="cv.html">CV</a>
   </nav>
 


### PR DESCRIPTION
## Summary
- Rename "Talks" navigation link to "Talks/Workshops" across all pages.
- Update Talks page title and H1 heading to "Talks/Workshops — Maria Federica Norelli".

## Testing
- `python -m http.server 8000` (served site locally and verified pages)
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68bb8d0cf47883268b2839e5e49dbd05